### PR TITLE
docs(aisa): route sign-in through CLI help

### DIFF
--- a/platform/aisa/SKILL.md
+++ b/platform/aisa/SKILL.md
@@ -14,7 +14,7 @@ First-time install and connect: https://aisa.one/docs/agent-quickstart.md
 
 ## Reuse
 
-Reuse a working official `aisa` skill, `@aisa-one/cli` **0.5.0 or later**, stored CLI credentials, or a unified MCP session. Prefer the CLI in any working terminal (PowerShell counts; Bash is not required). `AISA_API_KEY` overrides the stored key; if they conflict, explain the sources and leave custom setup alone. Never print credentials. `aisa whoami` is local only. Search and schema may be anonymous — they are not auth proof. Prove CLI auth with `aisa balance`. Failed login → `aisa login`. No credit → top up, not “missing key”.
+Reuse a working official `aisa` skill, `@aisa-one/cli` **0.5.0 or later**, stored CLI credentials, or a unified MCP session. Prefer the CLI in any working terminal (PowerShell counts; Bash is not required). `AISA_API_KEY` overrides the stored key; if they conflict, explain the sources and leave custom setup alone. Never print credentials. `aisa whoami` is local only. Search and schema may be anonymous — they are not auth proof. Prove CLI auth with `aisa balance`. When authentication is needed, read `aisa login --help` and follow it: relay the actual URL or input the CLI asks for through this current process until login finishes. No credit → top up, not “missing key”.
 
 ## Workflow
 

--- a/platform/aisa/SKILL.md
+++ b/platform/aisa/SKILL.md
@@ -14,7 +14,11 @@ First-time install and connect: https://aisa.one/docs/agent-quickstart.md
 
 ## Reuse
 
-Reuse a working official `aisa` skill, `@aisa-one/cli` **0.5.0 or later**, stored CLI credentials, or a unified MCP session. Prefer the CLI in any working terminal (PowerShell counts; Bash is not required). `AISA_API_KEY` overrides the stored key; if they conflict, explain the sources and leave custom setup alone. Never print credentials. `aisa whoami` is local only. Search and schema may be anonymous — they are not auth proof. Prove CLI auth with `aisa balance`. Before starting or continuing sign-in, read `aisa login --help`. Follow it to relay the actual URL and requested input through the current process until login finishes. No credit → top up, not “missing key”.
+Reuse a working official `aisa` skill, `@aisa-one/cli` **0.5.0 or later**, stored CLI credentials, or a unified MCP session. Prefer the CLI in any working terminal (PowerShell counts; Bash is not required). `AISA_API_KEY` overrides the stored key; if they conflict, explain the sources and leave custom setup alone. Never print credentials. `aisa whoami` is local only. Search and schema may be anonymous — they are not auth proof.
+
+## Sign-in
+
+Prove CLI auth with `aisa balance`. Before replying to a sign-in message or writing to its terminal, read `aisa login --help`. Follow it to interpret the CLI prompt and relay only the requested authorization result through the existing process. No credit → top up, not “missing key”.
 
 ## Workflow
 

--- a/platform/aisa/SKILL.md
+++ b/platform/aisa/SKILL.md
@@ -14,7 +14,7 @@ First-time install and connect: https://aisa.one/docs/agent-quickstart.md
 
 ## Reuse
 
-Reuse a working official `aisa` skill, `@aisa-one/cli` **0.5.0 or later**, stored CLI credentials, or a unified MCP session. Prefer the CLI in any working terminal (PowerShell counts; Bash is not required). `AISA_API_KEY` overrides the stored key; if they conflict, explain the sources and leave custom setup alone. Never print credentials. `aisa whoami` is local only. Search and schema may be anonymous — they are not auth proof. Prove CLI auth with `aisa balance`. When authentication is needed, read `aisa login --help` and follow it: relay the actual URL or input the CLI asks for through this current process until login finishes. No credit → top up, not “missing key”.
+Reuse a working official `aisa` skill, `@aisa-one/cli` **0.5.0 or later**, stored CLI credentials, or a unified MCP session. Prefer the CLI in any working terminal (PowerShell counts; Bash is not required). `AISA_API_KEY` overrides the stored key; if they conflict, explain the sources and leave custom setup alone. Never print credentials. `aisa whoami` is local only. Search and schema may be anonymous — they are not auth proof. Prove CLI auth with `aisa balance`. Before starting or continuing sign-in, read `aisa login --help`. Follow it to relay the actual URL and requested input through the current process until login finishes. No credit → top up, not “missing key”.
 
 ## Workflow
 


### PR DESCRIPTION
The official AIsa Skill now makes login help discovery explicit in a short Sign-in section: read `aisa login --help` before replying to a sign-in message or writing to its terminal, then follow the actual prompt through the existing process. In the observed cloud setup, a reply such as “done” was otherwise forwarded as terminal input or triggered another login.

Only `platform/aisa/SKILL.md` changes. It grows from450 to480 whitespace-delimited words (43→47 lines), while the login mechanics remain in CLI help. The `aisa` slug, AIsa display name, CLI command compatibility, working-connection reuse, credential precedence and quote/approval workflow are preserved.

Validation: locked catalog gate/CI pass with44 discoverable Skills; real Node-free curl fetch of all three files at0332d85 matches the candidate; native Codex loader reports enabled user-scope `aisa` / displayAIsa. A real Agent actually reads the packed help before selected interactions. Final full5/5 versus removed-help2/5 on five fixed fixtures; original R0/R1 failures retained. Login/PTY/balance are simulated, so this is not native ChatGPT Work OAuth or general reliability proof. [Evidence and reproduction](https://github.com/eddiearc/coding-context/blob/main/docs/generated/evidence/reports/aisa-setup-guidance-ownership.md).

Companions: [CLI PR23](https://github.com/AIsa-team/cli/pull/23) owns operational help; [held Docs PR100](https://github.com/AIsa-team/docs/pull/100) removes the duplicated login manual. Merged at the user’s explicit Skill-first request as f16c082361c5c3c0d75fdd67b3833b66e9aa8953. The default branch serves the exact reviewed three-file Skill and main catalog CI passes. CLI PR23 is now merged and npm0.5.2 is published with the expanded help. Docs PR100 remains draft and held for user review. Existing CLI commands remain compatible.
